### PR TITLE
Update survivor_auto_respawn.txt

### DIFF
--- a/survivor_auto_respawn/survivor_auto_respawn.txt
+++ b/survivor_auto_respawn/survivor_auto_respawn.txt
@@ -41,6 +41,13 @@
 				"windows"	"\x2A\x2A\x2A\x2A\x2A\x2A\x2A\x2A\xE8\x2A\x2A\x2A\x2A\x84\x2A\x75\x2A\x8B\x2A\xE8\x2A\x2A\x2A\x2A\xC6\x86"
 				/* ? ? ? ? ? ? ? ? E8 ? ? ? ? 84 ? 75 ? 8B ? E8 ? ? ? ? C6 86 */
 			}
+			"CTerrorPlayer::GoAwayFromKeyboard"
+			{
+				"library"		"server"
+				"linux"			"@_ZN13CTerrorPlayer18GoAwayFromKeyboardEv"
+				"windows"		"\x2A\x2A\x2A\x2A\x2A\x2A\x53\x56\x57\x8B\xF1\x8B\x06\x8B\x90\xC8\x08\x00\x00"
+				/* ? ? ? ? ? ? 53 56 57 8B F1 8B 06 8B 90 C8 08 00 00 */
+			}
 		}
     }
 }


### PR DESCRIPTION
L 01/21/2022 - 02:02:50: [SM] Exception reported: Failed to find signature: CTerrorPlayer::GoAwayFromKeyboard
L 01/21/2022 - 02:02:50: [SM] Blaming: survivor_auto_respawn.smx
L 01/21/2022 - 02:02:50: [SM] Call stack trace:
L 01/21/2022 - 02:02:50: [SM]   [0] SetFailState
L 01/21/2022 - 02:02:50: [SM]   [1] Line 941, D:\Files\steamapps\common\Left 4 Dead 2\left4dead2\addons\sourcemod\scripting\survivor_auto_respawn.sp::vLoadGameData
L 01/21/2022 - 02:02:50: [SM]   [2] Line 389, D:\Files\steamapps\common\Left 4 Dead 2\left4dead2\addons\sourcemod\scripting\survivor_auto_respawn.sp::OnPluginStart
L 01/21/2022 - 02:02:50: [SM] Unable to load plugin "survivor_auto_respawn.smx": Error detected in plugin startup (see error logs)