### PR TITLE
Update 'l4d2_map_vote' plugin

### DIFF
--- a/map_changer/gamedata/l4d2_source_keyvalues.txt
+++ b/map_changer/gamedata/l4d2_source_keyvalues.txt
@@ -8,25 +8,66 @@
 			{
 				"linux"
 				{
-					"signature"	"filesystem"
+					"signature"	"CDirector::OnServerShutdown"
+					"read"		"350"
+					"read"		"0"		// IFileSystem
+					"offset"	"4"		// IBaseFileSystem
 				}
 
 				"windows"
 				{
 					"signature"	"CDirector::OnServerShutdown"
-					"read"		"274"
+					"read"		"363"
+					"read"		"0"
+					"offset"	"4"
 				}
+			}
+		}
 
-				"read"	"0"
+		"Offsets"
+		{
+			"KeyValuesSize"
+			{
+				"linux"		"36"
+				"windows"	"36"
 			}
 		}
 
 		"Signatures"
 		{
-			"filesystem"
+			"KeyValues::operator_new"
 			{
 				"library"	"server"
-				"linux"		"@filesystem"
+				"linux"		"@_ZN9KeyValuesnwEj"
+				"windows"	"\x55\x8B\xEC\xFF\x15\x2A\x2A\x2A\x2A\x8B\x4D\x08\x8B\x10\x8B\x52\x04"
+			}
+
+			"KeyValues::KeyValues"
+			{
+				"library"	"server"
+				"linux"		"@_ZN9KeyValuesC2EPKc"
+				"windows"	"\x55\x8B\xEC\x33\xC0\x56\x8B\xF1\xC7\x06\xFF\xFF\xFF\xFF\x89\x46\x18\x89\x46\x14\x89\x46\x1C\x89\x46\x04\x89\x46\x08\x89\x46\x0C\x66\x89\x46\x10\x89\x46\x20\x66\x89\x46\x12\xFF\x15\x2A\x2A\x2A\x2A\x8B\x4D\x08\x8B\x10\x8B\x52\x0C\x6A\x01\x51\x8B\xC8\xFF\xD2\x89\x06"
+			}
+
+			"KeyValues::deleteThis"
+			{
+				"library"	"server"
+				"linux"		"@_ZN9KeyValues10deleteThisEv"
+				"windows"	"\x56\x8B\xF1\x85\xF6\x74\x2A\xE8"
+			}
+
+			"KeyValues::UsesEscapeSequences"
+			{
+				"library"	"server"
+				"linux"		"@_ZN9KeyValues19UsesEscapeSequencesEb"
+				"windows"	"\x55\x8B\xEC\x8A\x45\x08\x88\x41\x11"
+			}
+
+			"KeyValues::LoadFromFile"
+			{
+				"library"	"server"
+				"linux"		"@_ZN9KeyValues12LoadFromFileEP15IBaseFileSystemPKcS3_"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x3C\x53\x8B\x5D\x0C"
 			}
 
 			"KeyValues::GetName"
@@ -43,6 +84,13 @@
 				"linux"		"@_ZN9KeyValues7SetNameEPKc"
 				"windows"	"\x55\x8B\xEC\x56\x8B\xF1\xFF\x15\x2A\x2A\x2A\x2A\x8B\x4D\x08"
 				/* 55 8B EC 56 8B F1 FF 15 ? ? ? ? 8B 4D 08 */
+			}
+
+			"KeyValues::GetNameSymbol"
+			{
+				"library"	"server"
+				"linux"		"@_ZNK9KeyValues13GetNameSymbolEv"
+				"windows"	"\x85\xC9\x74\x2A\x8B\x01\xC3"
 			}
 
 			"KeyValues::GetDataType"
@@ -125,6 +173,13 @@
 				/* 55 8B EC 81 EC 10 01 00 00 A1 ? ? ? ? 33 C5 89 45 FC 8B C1 */
 			}
 
+			"KeyValues::FindKeyFromSymbol"
+			{
+				"library"	"server"
+				"linux"		"@_ZNK9KeyValues7FindKeyEi"
+				"windows"	"\x55\x8B\xEC\x85\xC9"
+			}
+
 			"KeyValues::GetFirstSubKey"
 			{
 				"library"	"server"
@@ -186,7 +241,6 @@
 				"library"	"server"
 				"linux"		"@_ZN9CDirector16OnServerShutdownEv"
 				"windows"	"\x2A\x2A\x2A\x2A\x2A\x2A\x8B\x2A\x8B\x8E\x2A\x2A\x2A\x2A\x8B\x2A\x8B\x2A\x57"
-				/* ? ? ? ? ? ? 8B ? 8B 8E ? ? ? ? 8B ? 8B ? 57 */
 			}
 		}
 	}

--- a/map_changer/scripting/include/l4d2_nativevote.inc
+++ b/map_changer/scripting/include/l4d2_nativevote.inc
@@ -1,14 +1,7 @@
-
 #if defined _l4d2_nativevote_included
  #endinput
 #endif
 #define _l4d2_nativevote_included
-
-enum L4D2NativeVote
-{
-	Invalid_Vote = 0,
-	Valid_Vote = 1,
-};
 
 enum VoteAction
 {
@@ -17,14 +10,14 @@ enum VoteAction
 	VoteAction_End,			// param1 = reason
 };
 
-enum
+enum 
 {
 	VOTE_YES = 1,
 	VOTE_NO = 2,
 };
 
 // VoteAction_End reason
-enum
+enum 
 {
 	VOTEEND_FULLVOTED = 1,	// All players have voted
 	VOTEEND_TIMEEND = 2,	// Time to vote ends
@@ -47,8 +40,8 @@ native bool L4D2NativeVote_IsAllowNewVote();
  */
 typedef L4D2VoteHandler = function void (L4D2NativeVote vote, VoteAction action, int param1, int param2);
 
-// methodmap of enum L4D2NativeVote
-methodmap L4D2NativeVote
+
+methodmap L4D2NativeVote 
 {
 	// Creates a new NativeVote.
 	// You should check L4D2NativeVote_IsAllowNewVote() first.
@@ -61,17 +54,20 @@ methodmap L4D2NativeVote
 	//
 	// @param fmt           text string format.
 	// @param ...           text string arguments.
+	public native void SetDisplayText(const char[] fmt, any ...);
 	public native void SetTitle(const char[] fmt, any ...);
 
 	// Returns text displayed on the vote screen.
 	//
 	// @param buffer        Buffer to store text.
 	// @param maxlength     Maximum length of the buffer.
+	public native void GetDisplayText(char[] buffer, int maxlength);
 	public native void GetTitle(char[] buffer, int maxlength);
 
 	// Arbitrary value storage or get.
-	property any Value {
-		public native set(any value);
+	property any Value
+	{
+		public native set(any val);
 		public native get();
 	}
 
@@ -79,18 +75,21 @@ methodmap L4D2NativeVote
 	//
 	// @param fmt           Info string format.
 	// @param ...           Info string arguments.
+	public native void SetInfoString(const char[] fmt, any ...);
 	public native void SetInfo(const char[] fmt, any ...);
 
 	// Get the stored info string.
 	//
 	// @param buffer        Buffer to store Info.
 	// @param maxlength     Maximum length of the buffer.
+	public native void GetInfoString(char[] buffer, int maxlength);
 	public native void GetInfo(char[] buffer, int maxlength);
 
 	// Get or set the client index of the player who initiated the vote.
 	//
 	// Default value 0.
-	property int Initiator {
+	property int Initiator
+	{
 		public native set(int client);
 		public native get();
 	}
@@ -104,19 +103,24 @@ methodmap L4D2NativeVote
 	//						Or vote is invalid, Or there are other vote in progress.
 	public native bool DisplayVote(int[] clients, int numClients, int time);
 
-	// Get current number of yes votes.
-	property int YesCount {
+	// Get or set the current affirmative vote.
+	property int YesCount
+	{
+		public native set(int value);
 		public native get();
 	}
 
-	// Get current number of no votes.
-	property int NoCount {
+	// Get or set the current negative vote.
+	property int NoCount
+	{
+		public native set(int value);
 		public native get();
 	}
 
 	// Get the number of players eligible to vote.
 	// Like numClients. but exclude clients that are not in the game.
-	property int PlayerCount {
+	property int PlayerCount
+	{
 		public native get();
 	}
 	
@@ -125,14 +129,14 @@ methodmap L4D2NativeVote
 	//
 	// @param fmt           text displayed on the vote screen after passed.
 	// @param ...           text string arguments.
-	public native void SetPass(const char[] fmt="", any ...);
+	public native void SetPass(const char[] fmt, any ...);
 
 	// Set vote Failed.
 	// You must manually call SetPass or SetFail in L4D2VoteHandler.
 	public native void SetFail();
 }
 
-public SharedPlugin __pl_l4d2_nativevote =
+public SharedPlugin __pl_l4d2_nativevote = 
 {
 	name = "l4d2_nativevote",
 	file = "l4d2_nativevote.smx",
@@ -148,17 +152,23 @@ public void __pl_l4d2_nativevote_SetNTVOptional()
 {
 	MarkNativeAsOptional("L4D2NativeVote_IsAllowNewVote");
 	MarkNativeAsOptional("L4D2NativeVote.L4D2NativeVote");
+	MarkNativeAsOptional("L4D2NativeVote.SetDisplayText");
 	MarkNativeAsOptional("L4D2NativeVote.SetTitle");
+	MarkNativeAsOptional("L4D2NativeVote.GetDisplayText");
 	MarkNativeAsOptional("L4D2NativeVote.GetTitle");
 	MarkNativeAsOptional("L4D2NativeVote.Value.set");
 	MarkNativeAsOptional("L4D2NativeVote.Value.get");
+	MarkNativeAsOptional("L4D2NativeVote.SetInfoString");
 	MarkNativeAsOptional("L4D2NativeVote.SetInfo");
+	MarkNativeAsOptional("L4D2NativeVote.GetInfoString");
 	MarkNativeAsOptional("L4D2NativeVote.GetInfo");
 	MarkNativeAsOptional("L4D2NativeVote.Initiator.set");
 	MarkNativeAsOptional("L4D2NativeVote.Initiator.get");
 	MarkNativeAsOptional("L4D2NativeVote.DisplayVote");
 	MarkNativeAsOptional("L4D2NativeVote.YesCount.get");
+	MarkNativeAsOptional("L4D2NativeVote.YesCount.set");
 	MarkNativeAsOptional("L4D2NativeVote.NoCount.get");
+	MarkNativeAsOptional("L4D2NativeVote.NoCount.set");
 	MarkNativeAsOptional("L4D2NativeVote.PlayerCount.get");
 	MarkNativeAsOptional("L4D2NativeVote.SetPass");
 	MarkNativeAsOptional("L4D2NativeVote.SetFail");

--- a/map_changer/scripting/include/l4d2_source_keyvalues.inc
+++ b/map_changer/scripting/include/l4d2_source_keyvalues.inc
@@ -3,7 +3,7 @@
 #endif
 #define _l4d2_source_keyvalues_included
 
-enum DataType
+enum /* DataType */
 {
 	TYPE_NONE = 0,
 	TYPE_STRING,
@@ -16,13 +16,21 @@ enum DataType
 	TYPE_NUMTYPES,
 }
 
+#define INVALID_KEY_SYMBOL (-1)
+
 // See link for instructions: https://github.com/alliedmodders/hl2sdk/blob/l4d2/public/tier1/KeyValues.h
 methodmap SourceKeyValues
 {
+	public native SourceKeyValues(const char[] name); // Need call deleteThis().
+	public native void deleteThis();
+	public native void UsesEscapeSequences(bool state);
+	public native bool LoadFromFile(const char[] file, const char[] pathID = NULL_STRING);
+
 	public native bool IsNull();
 	public native void GetName(char[] name, int maxlength);
 	public native void SetName(const char[] setName);
-	public native DataType GetDataType(const char[] key);
+	public native int GetNameSymbol();
+	public native any GetDataType(const char[] key);
 	public native void GetString(const char[] key, char[] value, int maxlength, const char[] defvalue = "");
 	public native void SetString(const char[] key, const char[] value);
 	public native void SetStringValue(const char[] value);
@@ -32,13 +40,14 @@ methodmap SourceKeyValues
 	public native void SetFloat(const char[] key, float value);
 	public native Address GetPtr(const char[] key, Address defvalue = Address_Null);
 	public native SourceKeyValues FindKey(const char[] key, bool bCreate = false);
+	public native SourceKeyValues FindKeyFromSymbol(int keySymbol);
 	public native SourceKeyValues GetFirstSubKey();
 	public native SourceKeyValues GetNextKey();
 	public native SourceKeyValues GetFirstTrueSubKey();
 	public native SourceKeyValues GetNextTrueSubKey();
 	public native SourceKeyValues GetFirstValue();
 	public native SourceKeyValues GetNextValue();
-	public native bool SaveToFile(const char[] file);
+	public native bool SaveToFile(const char[] file, const char[] pathID = NULL_STRING);
 }
 
 public SharedPlugin __pl_l4d2_source_keyvalues = 
@@ -55,9 +64,14 @@ public SharedPlugin __pl_l4d2_source_keyvalues =
 #if !defined REQUIRE_PLUGIN
 public void __pl_l4d2_source_keyvalues_SetNTVOptional()
 {
+	MarkNativeAsOptional("SourceKeyValues.SourceKeyValues");
+	MarkNativeAsOptional("SourceKeyValues.deleteThis");
+	MarkNativeAsOptional("SourceKeyValues.UsesEscapeSequences");
+	MarkNativeAsOptional("SourceKeyValues.LoadFromFile");
 	MarkNativeAsOptional("SourceKeyValues.IsNull");
 	MarkNativeAsOptional("SourceKeyValues.GetName");
 	MarkNativeAsOptional("SourceKeyValues.SetName");
+	MarkNativeAsOptional("SourceKeyValues.GetNameSymbol");
 	MarkNativeAsOptional("SourceKeyValues.GetDataType");
 	MarkNativeAsOptional("SourceKeyValues.GetString");
 	MarkNativeAsOptional("SourceKeyValues.SetString");
@@ -68,6 +82,7 @@ public void __pl_l4d2_source_keyvalues_SetNTVOptional()
 	MarkNativeAsOptional("SourceKeyValues.SetFloat");
 	MarkNativeAsOptional("SourceKeyValues.GetPtr");
 	MarkNativeAsOptional("SourceKeyValues.FindKey");
+	MarkNativeAsOptional("SourceKeyValues.FindKeyFromSymbol");
 	MarkNativeAsOptional("SourceKeyValues.GetFirstSubKey");
 	MarkNativeAsOptional("SourceKeyValues.GetNextKey");
 	MarkNativeAsOptional("SourceKeyValues.GetFirstTrueSubKey");

--- a/map_changer/scripting/l4d2_map_vote.sp
+++ b/map_changer/scripting/l4d2_map_vote.sp
@@ -2,9 +2,9 @@
 #pragma newdecls required
 
 #define PLUGIN_NAME				"L4D2 Map vote"
-#define PLUGIN_AUTHOR			"fdxx, sorallll"
+#define PLUGIN_AUTHOR			"fdxx, sorallll, HatsuneImagine"
 #define PLUGIN_DESCRIPTION		""
-#define PLUGIN_VERSION			"0.9"
+#define PLUGIN_VERSION			"1.0"
 #define PLUGIN_URL				""
 
 #define TRANSLATION_MISSIONS	"missions.phrases.txt"
@@ -111,9 +111,10 @@ public void OnPluginStart() {
 	RegConsoleCmd("sm_v3", 		cmdMapVote);
 	RegConsoleCmd("sm_maps", 	cmdMapVote);
 	RegConsoleCmd("sm_chmap", 	cmdMapVote);
-	RegConsoleCmd("sm_mapvote",	cmdMapVote);
+	RegConsoleCmd("sm_vmap",	cmdMapVote);
 	RegConsoleCmd("sm_votemap",	cmdMapVote);
 
+	RegConsoleCmd("sm_mapvote",		cmdMapNext);
 	RegConsoleCmd("sm_mapnext",		cmdMapNext);
 	RegConsoleCmd("sm_votenext",	cmdMapNext);
 
@@ -458,7 +459,7 @@ Action cmdMapNext(int client, int args) {
 	menu.SetTitle("选择下一张地图:");
 	menu.AddItem("", "官方地图");
 	menu.AddItem("", "三方地图");
-	menu.Display(client, 30);
+	menu.Display(client, MENU_TIME_FOREVER);
 	return Plugin_Handled;
 }
 
@@ -572,7 +573,8 @@ void VoteNextMap(int client, const char[] item) {
 	vote.SetInfo(buffer);
 
 	int team;
-	int clients[1];
+	int playerCount = 0;
+	int[] clients = new int[MaxClients];
 	for (int i = 1; i <= MaxClients; i++) {
 		if (!IsClientInGame(i) || IsFakeClient(i) || (team = GetClientTeam(i)) < 2 || team > 3)
 			continue;
@@ -580,9 +582,9 @@ void VoteNextMap(int client, const char[] item) {
 		fmt_Translate(item, buffer, sizeof buffer, i, item);
 		vote.SetTitle("设置下一张地图为: %s", buffer);
 
-		clients[0] = i;
-		vote.DisplayVote(clients, 1, 20);
+		clients[playerCount++] = i;
 	}
+	vote.DisplayVote(clients, playerCount, 20);
 }
 
 void NextMap_Handler(L4D2NativeVote vote, VoteAction action, int param1, int param2) {
@@ -643,7 +645,7 @@ Action cmdMapVote(int client, int args) {
 	menu.SetTitle("选择地图类型:");
 	menu.AddItem("", "官方地图");
 	menu.AddItem("", "三方地图");
-	menu.Display(client, 30);
+	menu.Display(client, MENU_TIME_FOREVER);
 	return Plugin_Handled;
 }
 
@@ -749,7 +751,7 @@ void ShowChaptersMenu(int client, const char[] item) {
 		PrintToChat(client, "无有效的章节地图存在");
 
 	menu.ExitBackButton = true;
-	menu.Display(client, 30);
+	menu.Display(client, MENU_TIME_FOREVER);
 }
 
 int Chapters_MenuHandler(Menu menu, MenuAction action, int client, int param2) {
@@ -786,7 +788,8 @@ void VoteChangeMap(int client, const char[] item) {
 	ExplodeString(item, "//", info, sizeof info, sizeof info[]);
 
 	int team;
-	int clients[1];
+	int playerCount = 0;
+	int[] clients = new int[MaxClients];
 	for (int i = 1; i <= MaxClients; i++) {
 		if (!IsClientInGame(i) || IsFakeClient(i) || (team = GetClientTeam(i)) < 2 || team > 3)
 			continue;
@@ -795,9 +798,9 @@ void VoteChangeMap(int client, const char[] item) {
 		fmt_Translate(info[1], info[1], sizeof info[], i, info[1]);
 		vote.SetTitle("更换地图: %s (%s)", info[0], info[1]);
 
-		clients[0] = i;
-		vote.DisplayVote(clients, 1, 20);
+		clients[playerCount++] = i;
 	}
+	vote.DisplayVote(clients, playerCount, 20);
 }
 
 void ChangeMap_Handler(L4D2NativeVote vote, VoteAction action, int param1, int param2) {

--- a/map_changer/scripting/l4d2_nativevote.sp
+++ b/map_changer/scripting/l4d2_nativevote.sp
@@ -5,61 +5,60 @@
 #include <sdktools>
 #include <l4d2_nativevote>
 
-#define PLUGIN_VERSION "0.2"
+#define VERSION "0.4"
 
-enum struct Vote {
-	bool InProgress;
-	bool VoteStarted;
-	char Title[64];
-	char Info[512];
+enum struct VoteData
+{
+	bool bVoteInProgress;
+	bool bVoteStart;
+	char sDisplayText[64];
 	any Value;
-	int Initiator;
-	int YesCount;
-	int NoCount;
-	int PlayerCount;
-	bool CanVote[MAXPLAYERS + 1];
+	char sInfoStr[512];
+	int iInitiator;
+	int iYesCount;
+	int iNoCount;
+	int iPlayerCount;
+	bool bCanVote[MAXPLAYERS+1];
 }
 
-Vote
-	g_Vote;
+VoteData g_VoteData;
+int g_iVoteController;
+PrivateForward g_hFwd;
+ConVar g_cvInitiatorAutoVoteYes;
+Handle g_hEndVoteTimer;
 
-int
-	g_iVote = -1;
-
-PrivateForward
-	g_fwdCreateVote;
-
-Handle
-	g_hVoteYesTimer,
-	g_hEndVoteTimer;
-
-ConVar
-	g_cvAutoVoteYes;
-
-public Plugin myinfo = {
+public Plugin myinfo = 
+{
 	name = "L4D2 Native vote",
 	author = "Powerlord, fdxx",
 	description = "Voting API to use the game's native vote panels",
-	version = PLUGIN_VERSION,
+	version = VERSION,
 	url = "https://github.com/fdxx/l4d2_nativevote"
 }
 
-public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max) {
+public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
+{
 	if (GetEngineVersion() != Engine_Left4Dead2) 
 		LogError("Plugin only supports L4D2"); // Only throw error, try to continue loading.
 
 	CreateNative("L4D2NativeVote.L4D2NativeVote", Native_CreateVote);
-	CreateNative("L4D2NativeVote.SetTitle", Native_SetTitle);
-	CreateNative("L4D2NativeVote.GetTitle", Native_GetTitle);
+	CreateNative("L4D2NativeVote.SetDisplayText", Native_SetDisplayText);
+	CreateNative("L4D2NativeVote.SetTitle", Native_SetDisplayText);
+	CreateNative("L4D2NativeVote.GetDisplayText", Native_GetDisplayText);
+	CreateNative("L4D2NativeVote.GetTitle", Native_GetDisplayText);
 	CreateNative("L4D2NativeVote.Value.set", Native_SetValue);
 	CreateNative("L4D2NativeVote.Value.get", Native_GetValue);
-	CreateNative("L4D2NativeVote.SetInfo", Native_SetInfo);
-	CreateNative("L4D2NativeVote.GetInfo", Native_GetInfo);
+	CreateNative("L4D2NativeVote.SetInfoString", Native_SetInfoStr);
+	CreateNative("L4D2NativeVote.SetInfo", Native_SetInfoStr);
+	CreateNative("L4D2NativeVote.GetInfoString", Native_GetInfoStr);
+	CreateNative("L4D2NativeVote.GetInfo", Native_GetInfoStr);
 	CreateNative("L4D2NativeVote.Initiator.set", Native_SetInitiator);
 	CreateNative("L4D2NativeVote.Initiator.get", Native_GetInitiator);
 	CreateNative("L4D2NativeVote.DisplayVote", Native_DisplayVote);
 	CreateNative("L4D2NativeVote.YesCount.get", Native_GetYesCount);
+	CreateNative("L4D2NativeVote.YesCount.set", Native_SetYesCount);
 	CreateNative("L4D2NativeVote.NoCount.get", Native_GetNoCount);
+	CreateNative("L4D2NativeVote.NoCount.set", Native_SetNoCount);
 	CreateNative("L4D2NativeVote.PlayerCount.get", Native_GetPlayerCount);
 	CreateNative("L4D2NativeVote.SetPass", Native_SetPass);
 	CreateNative("L4D2NativeVote.SetFail", Native_SetFail);
@@ -70,378 +69,343 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	return APLRes_Success;
 }
 
-public void OnPluginStart() {
-	CreateConVar("l4d2_nativevote_version", PLUGIN_VERSION, "L4D2 Native vote plugin version.", FCVAR_NOTIFY|FCVAR_DONTRECORD);
-	g_cvAutoVoteYes = CreateConVar("l4d2_nativevote_initiator_auto_voteyes", "1", "If 1, initiator will auto vote yes", FCVAR_NONE);
-
-	AddCommandListener(Listener_vote, "vote");
-	RegAdminCmd("sm_pass", cmdPass, ADMFLAG_VOTE);
-	RegAdminCmd("sm_veto", cmdVeto, ADMFLAG_VOTE);
+public void OnPluginStart()
+{
+	CreateConVar("l4d2_nativevote_version", VERSION, "version", FCVAR_NOTIFY);
+	g_cvInitiatorAutoVoteYes = CreateConVar("l4d2_nativevote_initiator_auto_voteyes", "1", "If 1, initiator will auto vote yes", FCVAR_NONE, true, 0.0, true, 1.0);
+	AddCommandListener(vote_Listener, "vote");
 }
 
-Action cmdPass(int client, int args) {
-	if (g_Vote.InProgress) {
-		g_Vote.NoCount = 0;
-		g_Vote.YesCount = g_Vote.PlayerCount;
-		UpdateVotes(VoteAction_End, VOTEEND_FULLVOTED);
-	}
-	else if (CheckVoteController() && IsGameVoteActive()){
-		SetEntProp(g_iVote, Prop_Send, "m_votesNo", 0);
-		SetEntProp(g_iVote, Prop_Send, "m_votesYes", GetEntProp(g_iVote, Prop_Send, "m_potentialVotes"));
-
-		for (int i = 1; i <= MaxClients; i++) {
-			if (!IsClientInGame(i))
-				continue;
-
-			FakeClientCommand(i, "Vote Yes");
-		}
-	}
-
-	return Plugin_Handled;
-}
-
-Action cmdVeto(int client, int args) {
-	if (g_Vote.InProgress) {
-		g_Vote.YesCount = 0;
-		g_Vote.NoCount = g_Vote.PlayerCount;
-		UpdateVotes(VoteAction_End, VOTEEND_FULLVOTED);
-	}
-	else if (CheckVoteController() && IsGameVoteActive()){
-		SetEntProp(g_iVote, Prop_Send, "m_votesYes", 0);
-		SetEntProp(g_iVote, Prop_Send, "m_votesNo", GetEntProp(g_iVote, Prop_Send, "m_potentialVotes"));
-
-		for (int i = 1; i <= MaxClients; i++) {
-			if (!IsClientInGame(i))
-				continue;
-
-			FakeClientCommand(i, "Vote No");
-		}
-	}
-
-	return Plugin_Handled;
-}
-
-public void OnClientDisconnect(int client) {
-	if (!g_Vote.InProgress)
-		return;
-
-	if (!g_Vote.CanVote[client])
-		return;
-
-	g_Vote.PlayerCount--;
-	g_Vote.CanVote[client] = false;
-	if (!g_Vote.PlayerCount)
-		UpdateVotes(VoteAction_End, VOTEEND_FULLVOTED);
-}
-
-public void OnMapStart() {
-	delete g_hVoteYesTimer;
+public void OnMapStart()
+{
 	delete g_hEndVoteTimer;
-	g_Vote.InProgress = false;
-	g_Vote.VoteStarted = false;
+	g_VoteData.bVoteInProgress = false;
 }
 
-public void OnMapEnd() {
-	delete g_hVoteYesTimer;
+public void OnMapEnd()
+{
 	delete g_hEndVoteTimer;
-	g_Vote.InProgress = false;
-	g_Vote.VoteStarted = false;
+	g_VoteData.bVoteInProgress = false;
 }
 
 // public native L4D2NativeVote CreateVote(L4D2VoteHandler handler);
-any Native_CreateVote(Handle plugin, int numParams) {
-	if (!IsAllowNewVote()) {
+any Native_CreateVote(Handle plugin, int numParams)
+{
+	if (!IsAllowNewVote())
+	{
 		ThrowNativeError(SP_ERROR_NATIVE, "Failed to create new vote");
-		return Invalid_Vote;
+		return 0;
 	}
 
 	ResetVote();
-	g_fwdCreateVote = new PrivateForward(ET_Ignore, Param_Cell, Param_Cell, Param_Cell, Param_Cell);
-	g_fwdCreateVote.AddFunction(plugin, GetNativeFunction(1));
-	SetEntProp(g_iVote, Prop_Send, "m_activeIssueIndex", 0);
-	g_Vote.InProgress = true;
+	g_hFwd = new PrivateForward(ET_Ignore, Param_Cell, Param_Cell, Param_Cell, Param_Cell);
+	g_hFwd.AddFunction(plugin, GetNativeFunction(1));
+	SetVoteEntityStatus(0);
+	g_VoteData.bVoteInProgress = true;
 
-	return Valid_Vote;
+	return 1;
 }
 
-// public native void SetTitle(const char[] fmt, any ...);
-int Native_SetTitle(Handle plugin, int numParams) {
-	FormatNativeString(0, 2, 3, sizeof g_Vote.Title, _, g_Vote.Title);
+// public native void SetDisplayText(const char[] fmt, any ...);
+any Native_SetDisplayText(Handle plugin, int numParams)
+{
+	FormatNativeString(0, 2, 3, sizeof(g_VoteData.sDisplayText), _, g_VoteData.sDisplayText);
 	return 0;
 }
 
-// public native void GetTitle(char[] buffer, int maxlength);
-int Native_GetTitle(Handle plugin, int numParams) {
-	SetNativeString(2, g_Vote.Title, GetNativeCell(3));
+// public native void GetDisplayText(char[] buffer, int maxlength);
+any Native_GetDisplayText(Handle plugin, int numParams)
+{
+	SetNativeString(2, g_VoteData.sDisplayText, GetNativeCell(3));
 	return 0;
 }
 
-// public native void SetInfo(const char[] fmt, any ...);
-int Native_SetInfo(Handle plugin, int numParams) {
-	FormatNativeString(0, 2, 3, sizeof g_Vote.Info, _, g_Vote.Info);
+any Native_SetValue(Handle plugin, int numParams)
+{
+	g_VoteData.Value = GetNativeCell(2);
 	return 0;
 }
 
-// public native void GetInfo(char[] buffer, int maxlength);
-int Native_GetInfo(Handle plugin, int numParams) {
-	SetNativeString(2, g_Vote.Info, GetNativeCell(3));
+any Native_GetValue(Handle plugin, int numParams)
+{
+	return g_VoteData.Value;
+}
+
+// public native void SetInfoString(const char[] fmt, any ...);
+any Native_SetInfoStr(Handle plugin, int numParams)
+{
+	FormatNativeString(0, 2, 3, sizeof(g_VoteData.sInfoStr), _, g_VoteData.sInfoStr);
 	return 0;
 }
 
-int Native_SetValue(Handle plugin, int numParams) {
-	g_Vote.Value = GetNativeCell(2);
+// public native void GetInfoString(char[] buffer, int maxlength);
+any Native_GetInfoStr(Handle plugin, int numParams)
+{
+	SetNativeString(2, g_VoteData.sInfoStr, GetNativeCell(3));
 	return 0;
 }
 
-any Native_GetValue(Handle plugin, int numParams) {
-	return g_Vote.Value;
-}
-
-int Native_SetInitiator(Handle plugin, int numParams) {
-	g_Vote.Initiator = GetNativeCell(2);
+any Native_SetInitiator(Handle plugin, int numParams)
+{
+	g_VoteData.iInitiator = GetNativeCell(2);
 	return 0;
 }
 
-int Native_GetInitiator(Handle plugin, int numParams) {
-	return g_Vote.Initiator;
+any Native_GetInitiator(Handle plugin, int numParams)
+{
+	return g_VoteData.iInitiator;
 }
 
 // public native bool DisplayVote(int[] clients, int numClients, int time);
-any Native_DisplayVote(Handle plugin, int numParams) {
-	L4D2NativeVote vote = GetNativeCell(1);
-	if (vote != Valid_Vote || !g_Vote.InProgress)
+any Native_DisplayVote(Handle plugin, int numParams)
+{
+	if (!GetNativeCell(1) || !g_VoteData.bVoteInProgress || g_VoteData.bVoteStart)
 		return false;
 
-	int size = GetNativeCell(3);
-	int[] clients = new int[size];
-	GetNativeArray(2, clients, size);
+	int numClients = GetNativeCell(3);
+	int[] buffer = new int[numClients];
+	GetNativeArray(2, buffer, numClients);
 
-	int i;
 	int client;
-	int numVote;
-	for (; i < size; i++) {
-		client = clients[i];
-		if (client > 0 && client <= MaxClients && IsClientInGame(client)) {
-			clients[numVote++] = client;
-			g_Vote.CanVote[client] = true;
+	int[] clients = new int[numClients];
+	
+	for (int i = 0; i < numClients; i++)
+	{
+		client = buffer[i];
+		if (client > 0 && client <= MaxClients && IsClientInGame(client))
+		{
+			clients[g_VoteData.iPlayerCount++] = client;
+			g_VoteData.bCanVote[client] = true;
 		}
 	}
-
-	if (!numVote) {
-		if (!g_Vote.PlayerCount)
-			ResetVote();
-
+	
+	if (g_VoteData.iPlayerCount < 1)
+	{
+		ResetVote();
 		return false;
 	}
-
-	g_Vote.PlayerCount += numVote;
-	int initiator = g_Vote.Initiator;
-	char name[MAX_NAME_LENGTH];
+	
+	int initiator = g_VoteData.iInitiator;
+	char sName[128];
 	if (initiator > 0 && initiator <= MaxClients && IsClientInGame(initiator))
-		FormatEx(name, sizeof name, "%N", initiator);
+	{
+		FormatEx(sName, sizeof(sName), "%N", initiator);
+		if (g_cvInitiatorAutoVoteYes.BoolValue)
+			CreateTimer(0.1, InitiatorVote_Timer, GetClientUserId(initiator));
+	}
 
-	BfWrite bf = UserMessageToBfWrite(StartMessage("VoteStart", clients, numVote, USERMSG_RELIABLE));
+	BfWrite bf = UserMessageToBfWrite(StartMessage("VoteStart", clients, g_VoteData.iPlayerCount, USERMSG_RELIABLE));
 	bf.WriteByte(-1);							// team. Valve represents no team as -1
 	bf.WriteByte(initiator);					// initiator
 	bf.WriteString("#L4D_TargetID_Player");		// issue. L4D_TargetID_Player which will let you create any vote you want.
-	bf.WriteString(g_Vote.Title);				// Vote issue text
-	bf.WriteString(name);						// initiatorName
+	bf.WriteString(g_VoteData.sDisplayText);	// Vote issue text
+	bf.WriteString(sName);						// initiatorName
 	EndMessage();
 
-	if (!g_Vote.VoteStarted) {
-		g_Vote.VoteStarted = true;
-		UpdateVotes(VoteAction_Start, initiator);
+	g_VoteData.bVoteStart = true;
 
-		if (name[0] && g_cvAutoVoteYes.BoolValue) {
-			delete g_hVoteYesTimer;
-			g_hVoteYesTimer = CreateTimer(0.1, tmrVoteYes, GetClientUserId(initiator));
-		}
-	}
-
+	int time = GetNativeCell(4);
 	delete g_hEndVoteTimer;
-	g_hEndVoteTimer = CreateTimer(float(GetNativeCell(4)), tmrEndVote);
+	g_hEndVoteTimer = CreateTimer(float(time), EndVote_Timer);
 
+	UpdateVotes(VoteAction_Start, initiator);
 	return true;
 }
 
-Action tmrVoteYes(Handle timer, int client) {
-	g_hVoteYesTimer = null;
+Action InitiatorVote_Timer(Handle timer, int userid)
+{
+	if (!g_VoteData.bVoteInProgress)
+		return Plugin_Continue;
 
-	if (!g_Vote.InProgress)
-		return Plugin_Stop;
-
-	if ((client = GetClientOfUserId(client)) && IsClientInGame(client))
+	int client = GetClientOfUserId(userid);
+	if (client > 0 && client <= MaxClients && IsClientInGame(client))
 		FakeClientCommand(client, "Vote Yes");
-
 	return Plugin_Continue;
 }
 
-int Native_GetYesCount(Handle plugin, int numParams) {
-	return g_Vote.YesCount;
+any Native_GetYesCount(Handle plugin, int numParams)
+{
+	return g_VoteData.iYesCount;
 }
 
-int Native_GetNoCount(Handle plugin, int numParams) {
-	return g_Vote.NoCount;
+any Native_SetYesCount(Handle plugin, int numParams)
+{
+	g_VoteData.iYesCount = GetNativeCell(2);
+	return 0;
 }
 
-int Native_GetPlayerCount(Handle plugin, int numParams) {
-	return g_Vote.PlayerCount;
+any Native_GetNoCount(Handle plugin, int numParams)
+{
+	return g_VoteData.iNoCount;
 }
 
-Action tmrEndVote(Handle timer) {
-	g_hEndVoteTimer = null;
+any Native_SetNoCount(Handle plugin, int numParams)
+{
+	g_VoteData.iNoCount = GetNativeCell(2);
+	return 0;
+}
 
-	if (g_Vote.InProgress)
+any Native_GetPlayerCount(Handle plugin, int numParams)
+{
+	return g_VoteData.iPlayerCount;
+}
+
+Action EndVote_Timer(Handle timer)
+{
+	if (g_VoteData.bVoteInProgress)
+	{
 		UpdateVotes(VoteAction_End, VOTEEND_TIMEEND);
-
+	}
+	g_hEndVoteTimer = null;
 	return Plugin_Continue;
 }
 
-Action Listener_vote(int client, const char[] command, int argc) {
-	if (!g_Vote.InProgress || !g_Vote.CanVote[client])
-		return Plugin_Continue;
-
-	char buffer[5];
-	if (!GetCmdArgString(buffer, sizeof buffer))
-		return Plugin_Continue;
-
-	if (strcmp(buffer, "Yes", false) == 0) {
-		g_Vote.YesCount++;
-		UpdateVotes(VoteAction_PlayerVoted, client, VOTE_YES);
+Action vote_Listener(int client, const char[] command, int argc)
+{
+	if (g_VoteData.bVoteInProgress && g_VoteData.bCanVote[client])
+	{
+		g_VoteData.bCanVote[client] = false;
+		char sVote[4];
+		if (GetCmdArgString(sVote, sizeof(sVote)) > 1)
+		{
+			if (strcmp(sVote, "Yes", false) == 0)
+			{
+				g_VoteData.iYesCount++;
+				UpdateVotes(VoteAction_PlayerVoted, client, VOTE_YES);
+			}
+			else if (strcmp(sVote, "No", false) == 0)
+			{
+				g_VoteData.iNoCount++;
+				UpdateVotes(VoteAction_PlayerVoted, client, VOTE_NO);
+			}
+		}
 	}
-	else if (strcmp(buffer, "No", false) == 0) {
-		g_Vote.NoCount++;
-		UpdateVotes(VoteAction_PlayerVoted, client, VOTE_NO);
-	}
-	else
-		return Plugin_Continue;
-	
-	g_Vote.CanVote[client] = false;
+
 	return Plugin_Continue;
 }
 
 // function void (L4D2NativeVote vote, VoteAction action, int param1, int param2);
-void UpdateVotes(VoteAction action, int param1 = -1, int param2 = -1) {
-	if (!g_Vote.InProgress)
-		return;
+void UpdateVotes(VoteAction action, int param1 = -1, int param2 = -1)
+{
+	if (!g_VoteData.bVoteInProgress) return;
 
 	Event event = CreateEvent("vote_changed", true);
-	event.SetInt("yesVotes", g_Vote.YesCount);
-	event.SetInt("noVotes", g_Vote.NoCount);
-	event.SetInt("potentialVotes", g_Vote.PlayerCount);
+	event.SetInt("yesVotes", g_VoteData.iYesCount);
+	event.SetInt("noVotes", g_VoteData.iNoCount);
+	event.SetInt("potentialVotes", g_VoteData.iPlayerCount);
 	event.Fire();
 
-	switch (action) {
-		case VoteAction_Start: {
-			Call_StartForward(g_fwdCreateVote);
-			Call_PushCell(Valid_Vote);
-			Call_PushCell(action);
-			Call_PushCell(param1);
-			Call_PushCell(param2);
-			Call_Finish();
-		}
-
-		case VoteAction_PlayerVoted: {
-			Call_StartForward(g_fwdCreateVote);
-			Call_PushCell(Valid_Vote);
+	switch (action)
+	{
+		case VoteAction_Start, VoteAction_PlayerVoted:
+		{
+			Call_StartForward(g_hFwd);
+			Call_PushCell(0);
 			Call_PushCell(action);
 			Call_PushCell(param1);
 			Call_PushCell(param2);
 			Call_Finish();
 
-			if (g_Vote.YesCount + g_Vote.NoCount >= g_Vote.PlayerCount)
+			if (g_VoteData.iYesCount + g_VoteData.iNoCount >= g_VoteData.iPlayerCount)
+			{
+				for (int i; i <= MaxClients; i++)
+					g_VoteData.bCanVote[i] = false;
+					
 				UpdateVotes(VoteAction_End, VOTEEND_FULLVOTED);
+			}
 		}
-
-		case VoteAction_End: {
-			Call_StartForward(g_fwdCreateVote);
-			Call_PushCell(Valid_Vote);
+		case VoteAction_End:
+		{
+			Call_StartForward(g_hFwd);
+			Call_PushCell(0);
 			Call_PushCell(action);
 			Call_PushCell(param1);
 			Call_PushCell(param2);
 			Call_Finish();
-
-			ResetVote();
 		}
 	}
 }
 
-int Native_SetPass(Handle plugin, int numParams) {
-	char out_string[64];
-	if (numParams > 1)
-		FormatNativeString(0, 2, 3, sizeof out_string, _, out_string);
+int Native_SetPass(Handle plugin, int numParams)
+{
+	char sMsg[64];
+	FormatNativeString(0, 2, 3, sizeof(sMsg), _, sMsg);
 
 	BfWrite bf = UserMessageToBfWrite(StartMessageAll("VotePass", USERMSG_RELIABLE));
 	bf.WriteByte(-1);
 	bf.WriteString("#L4D_TargetID_Player");
-	bf.WriteString(out_string);
+	bf.WriteString(sMsg);
 	EndMessage();
-	CreateTimer(0.1, tmrResetVote);
+	CreateTimer(1.0, ResetVote_Timer);
 	return 0;
 }
 
-int Native_SetFail(Handle plugin, int numParams) {
+int Native_SetFail(Handle plugin, int numParams)
+{
 	BfWrite bf = UserMessageToBfWrite(StartMessageAll("VoteFail", USERMSG_RELIABLE));
 	bf.WriteByte(-1);
 	EndMessage();
-	CreateTimer(0.1, tmrResetVote);
+	CreateTimer(1.0, ResetVote_Timer);
 	return 0;
 }
 
-Action tmrResetVote(Handle timer) {
+Action ResetVote_Timer(Handle timer)
+{
 	ResetVote();
 	return Plugin_Continue;
 }
 
-void ResetVote() {
-	delete g_hVoteYesTimer;
+void ResetVote()
+{
+	g_VoteData.bVoteInProgress = false;
+	g_VoteData.bVoteStart = false;
+
 	delete g_hEndVoteTimer;
-	delete g_fwdCreateVote;
-	g_Vote.InProgress = false;
-	g_Vote.VoteStarted = false;
-
-	g_Vote.Title[0] = '\0';
-	g_Vote.Info[0] = '\0';
-	g_Vote.Value = 0;
-	g_Vote.Initiator = 0;
-	g_Vote.YesCount = 0;
-	g_Vote.NoCount = 0;
-	g_Vote.PlayerCount = 0;
-
-	for (int i; i <= MaxClients; i++)
-		g_Vote.CanVote[i] = false;
+	delete g_hFwd;
 
 	if (CheckVoteController())
-		SetEntProp(g_iVote, Prop_Send, "m_activeIssueIndex", -1);
+		SetVoteEntityStatus(-1);
+
+	g_VoteData.sDisplayText[0] = '\0';
+	g_VoteData.Value = 0;
+	g_VoteData.sInfoStr[0] = '\0';
+	g_VoteData.iInitiator = 0;
+	g_VoteData.iYesCount = 0;
+	g_VoteData.iNoCount = 0;
+	g_VoteData.iPlayerCount = 0;
+
+	for (int i; i <= MaxClients; i++)
+		g_VoteData.bCanVote[i] = false;
 }
 
-any Native_IsAllowNewVote(Handle plugin, int numParams) {
+any Native_IsAllowNewVote(Handle plugin, int numParams)
+{
 	return IsAllowNewVote();
 }
 
-bool IsAllowNewVote() {
-	if (!g_Vote.InProgress)
-		return CheckVoteController() && !IsGameVoteActive();
-
+bool IsAllowNewVote()
+{
+	if (!g_VoteData.bVoteInProgress && CheckVoteController())
+	{
+		return GetVoteEntityStatus() == -1;
+	}
 	return false;
 }
 
-bool CheckVoteController() {
-	int entity = -1;
-	if (g_iVote != -1)
-		entity = EntRefToEntIndex(g_iVote);
-
-	if (entity == -1) {
-		entity = FindEntityByClassname(MaxClients + 1, "vote_controller");
-		if (entity == -1)
-			return false;
-
-		g_iVote = EntIndexToEntRef(entity);
-	}
-
-	return true;
+bool CheckVoteController()
+{
+	g_iVoteController = FindEntityByClassname(MaxClients+1, "vote_controller");
+	return g_iVoteController != -1;
 }
 
-bool IsGameVoteActive() {
-	return GetEntProp(g_iVote, Prop_Send, "m_activeIssueIndex") > -1;
+int GetVoteEntityStatus()
+{
+	return GetEntProp(g_iVoteController, Prop_Send, "m_activeIssueIndex");
 }
+
+void SetVoteEntityStatus(int value)
+{
+	SetEntProp(g_iVoteController, Prop_Send, "m_activeIssueIndex", value);
+}
+
+


### PR DESCRIPTION
1. 将前置依赖 `l4d2_source_keyvalues` 和 `l4d2_nativevote` 升级至最新版。



---

2. 修复 `l4d2_map_vote` 不适配最新版 `l4d2_nativevote` 的问题。当投票下一张地图时，只有索引最小的玩家能看到投票窗口，其他玩家看不到投票窗口且无法支持或反对的bug（且投票窗口中只有1个槽位，索引最小的玩家支持或反对后投票框则关闭）。



原本 **向所有玩家展示原生投票窗口** 的逻辑如下：

```c
void VoteChangeMap(int client, const char[] item) {
    ......

    int clients[1];
    for (int i = 1; i <= MaxClients; i++) {
        if (!IsClientInGame(i) || IsFakeClient(i) || (team = GetClientTeam(i)) < 2 || team > 3)
            continue;

        fmt_Translate(info[0], info[0], sizeof info[], i, info[0]);
        fmt_Translate(info[1], info[1], sizeof info[], i, info[1]);
        vote.SetTitle("更换地图: %s (%s)", info[0], info[1]);

        clients[0] = i;
        vote.DisplayVote(clients, 1, 20);
    }
}
```



改进后的 **向所有玩家展示原生投票窗口** 的逻辑如下：

```c
void VoteChangeMap(int client, const char[] item) {
    ......

    int playerCount = 0;
    int[] clients = new int[MaxClients];
    for (int i = 1; i <= MaxClients; i++) {
        if (!IsClientInGame(i) || IsFakeClient(i) || (team = GetClientTeam(i)) < 2 || team > 3)
            continue;

        fmt_Translate(info[0], info[0], sizeof info[], i, info[0]);
        fmt_Translate(info[1], info[1], sizeof info[], i, info[1]);
        vote.SetTitle("更换地图: %s (%s)", info[0], info[1]);

        clients[playerCount++] = i;
    }
    vote.DisplayVote(clients, playerCount, 20);
}
```



改动如下：

1. 将 `clients` 变量改为容量 `MaxClients` 大小的数组，存入所有 需要向其展示原生投票窗口 的玩家。
2. 定义 `playerCount` 变量，存入总玩家数，用于设置原生投票窗口中的槽位数。
3. 将 `l4d2_nativevote` 的 `DisplayVote()` 方法的调用从for循环中移出，放到循环执行完毕后。



此bug得以解决。当投票时，所有玩家均能看到原生投票窗口并能正常进行投票。